### PR TITLE
Increase connection and wait timeouts for driver initialization

### DIFF
--- a/src/tests.js
+++ b/src/tests.js
@@ -850,6 +850,8 @@ async function driverStart(capabilities) {
     port: 4723,
     path: "/",
     capabilities,
+    connectionRetryTimeout: 120000, // 2 minutes
+    waitforTimeout: 120000, // 2 minutes
   });
   driver.state = { url: "", x: null, y: null };
   return driver;


### PR DESCRIPTION
- Set connectionRetryTimeout to 2 minutes
- Set waitforTimeout to 2 minutes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Increased timeout durations for connection retries and wait-for commands during driver initialization, reducing the likelihood of timeout errors in long-running or slow test environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->