### PR TITLE
Support request headers as strings and parse steingified JSON for request bodies

### DIFF
--- a/dev/doc-content.md
+++ b/dev/doc-content.md
@@ -1,21 +1,11 @@
-# Doc Detective documentation overview
+```
+PATCH https://orc.wiremockapi.cloud/satellites/8 HTTP/1.1
+Host: orc.wiremockapi.cloud
+Content-Type: application/json
+Accept: application/json
+Content-Length: 25
 
-[comment]: # (test start {"id":"search-kittens", "detectSteps":false})
-
-[Doc Detective documentation](http://doc-detective.com) is split into a few key sections:
-[comment]: # (step {"action":"goTo", "url":"http://doc-detective.com"})
-
--   The landing page discusses what Doc Detective is, what it does, and who might find it useful.
--   [Get started](https://doc-detective.com/get-started.html) covers how to quickly get up and running with Doc Detective.
-    [comment]: # (step {"action":"goTo", "url":"https://doc-detective.com/get-started.html"})
--   The [references](https://doc-detective.com/reference/) detail the various JSON objects that Doc Detective expects for configs, test specifications, tests, actions, and more. Each object schema includes an object description, field definitions, and examples.
-    [comment]: # (step {"action":"goTo", "url":"https://doc-detective.com/reference/"})
-    [comment]: # (step {"action":"goTo", "url":"https://doc-detective.com/reference/schemas/config.html"})
-    [comment]: # (step {"action":"find", "selector":"h2#description", "matchText":"Description"})
-    [comment]: # (step {"action":"find", "selector":"h2#fields", "matchText":"Fields"})
-    [comment]: # (step {"action":"find", "selector":"h2#examples", "matchText":"Examples"})
-
-![](reference.png)
-[comment]: # (step {"action":"saveScreenshot", "path":"reference.png", "directory":"dev", "maxVariation":5, "overwrite":"byVariation"})
-
-[comment]: # (test end)
+{
+  "status": "maintenance"
+}
+```

--- a/dev/index.js
+++ b/dev/index.js
@@ -27,14 +27,8 @@ main();
 
 async function main() {
   const json = {
-    input: "./dev/dev.spec.yaml",
+    input: "./dev/doc-content.md",
     logLevel: "debug",
-    runOn: [
-      {
-        platforms: ["windows", "linux", "mac"],
-        browsers: [{ name: "firefox", headless: false }],
-      },
-    ],
   };
   // console.log(json);
   result = await runTests(json);

--- a/test/artifacts/httpRequestFormat.md
+++ b/test/artifacts/httpRequestFormat.md
@@ -1,0 +1,9 @@
+```
+POST http://localhost:8080/api/status HTTP/1.1
+Content-Type: application/json
+Accept: application/json
+
+{
+  "status": "maintenance"
+}
+```


### PR DESCRIPTION
- Replace the content of `doc-content.md` with a new HTTP request example.
- Change the input file in `index.js` to point to `doc-content.md`.
- Standardize HTTP request headers from string to object format in `httpRequest.js`.
- Parse request body as JSON if it is a stringified JSON.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to provide a concise HTTP PATCH request example, replacing previous detailed content.
  - Added a new example showcasing a POST request with JSON headers and body.

- **New Features**
  - Improved handling of HTTP request headers and bodies to ensure consistent formatting and parsing.

- **Chores**
  - Adjusted test configuration to use the updated documentation file and removed platform/browser specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->