### PR TITLE
fix: recording on macos #273

### DIFF
--- a/src/tests/startRecording.js
+++ b/src/tests/startRecording.js
@@ -1,4 +1,5 @@
 const { validate } = require("doc-detective-common");
+const { log } = require("../utils");
 const { instantiateCursor } = require("./moveTo");
 const path = require("path");
 const fs = require("fs");
@@ -178,6 +179,7 @@ async function startRecording({ config, context, step, driver }) {
         "Failed to start recording. getDisplayMedia may have been rejected. " +
         "On macOS, ensure Chrome has screen recording permission in " +
         "System Preferences > Privacy & Security > Screen Recording.";
+      log(config, "error", result.description);
       // Clean up: close the recorder tab and switch back
       await driver.closeWindow();
       await driver.switchToWindow(originalTab);

--- a/src/tests/stopRecording.js
+++ b/src/tests/stopRecording.js
@@ -36,6 +36,18 @@ async function stopRecording({ config, step, driver }) {
 
       // Switch to recording tab
       await driver.switchToWindow(config.recording.tab);
+      // Verify the recorder was properly initialized
+      const recorderExists = await driver.execute(() => {
+        return typeof window.recorder !== "undefined" && window.recorder !== null;
+      });
+      if (!recorderExists) {
+        result.status = "FAIL";
+        result.description =
+          "Recording was not properly started. The recorder object doesn't exist in the browser context.";
+        await driver.closeWindow();
+        config.recording = null;
+        return result;
+      }
       // Stop recording
       await driver.execute(() => {
         window.recorder.stop();


### PR DESCRIPTION
I ran into #273, ran into the undefined error in stop step, and saw a blank tab with the title RECORD_ME next to the other tab.


  driver.execute() sends a script to the browser and waits for it to return synchronously. But getDisplayMedia() returns a Promise [[1]](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getDisplayMedia#return_value) . So when the original code called captureAndDownload() without await on line 164, here's what happened:

  1. driver.execute() sends the script to Chrome
  2. Chrome starts executing it, hits captureAndDownload(), which kicks off a promise
  3. The function body ends — no return value, no await — so Chrome reports back "done, result: undefined"
  4. driver.execute() resolves on the Node.js side
  5. Node.js immediately switches back to the original tab (line 167)
  6. Meanwhile, in the recorder tab, getDisplayMedia() is still waiting to resolve

That tab switch is the killer on macOS. The --auto-select-desktop-capture-source=RECORD_ME flag tells Chrome to auto-pick the tab titled "RECORD_ME," but the code has already moved focus away. On macOS specifically, this race seems to consistently cause getDisplayMedia() to reject or return nothing, so window.recorder never gets created.

driver.executeAsync() fixes this because it doesn't resolve on the Node.js side until the browser code explicitly calls the done callback. So the sequence becomes:

  1. driver.executeAsync() sends the script to Chrome
  2. Chrome calls getDisplayMedia(), awaits it, creates the MediaRecorder, calls .start()
  3. Only then does it call done(true)
  4. driver.executeAsync() resolves on the Node.js side
  5. Now Node.js switches tabs — recording is already running

Checking recorderStarted before populating config.recording follows directly from this. If getDisplayMedia() rejects (permissions not granted, API failure, etc.), the done(false) path fires, and startRecording returns FAIL immediately instead of pretending everything worked and letting stopRecording crash later.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recording reliability by switching to an asynchronous start so screen capture is confirmed before proceeding.
  * Added clearer failure handling and messaging when recording cannot start, with proper cleanup and UI/title restoration.
  * Prevented attempts to stop a recorder that was never initialized by validating recorder state before stopping.
  * Ensured download and cleanup flows run on both success and failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->